### PR TITLE
feat(toolParticipant): enhance language model selection with fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cogent",
     "displayName": "Cogent",
     "description": "Cogent is a Copilot extension that gives it agenting capabilities like executing commands, editing and reading files, and more.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "engines": {
         "vscode": "^1.95.0"
     },


### PR DESCRIPTION
## Changes

- Add MODEL_SELECTOR constant for primary language model configuration
- Implement fallback to gpt-4o when claude-3.5-sonnet is unavailable
- Add error handling with user feedback when no language model is available
- Improve code formatting and whitespace consistency

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring (no functional changes, no API changes)